### PR TITLE
Don't create files when they already exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ if(args[0] === "create-controller" || args[0]=== "controller-generator"){
 }
 
 const pathExists = `./Controllers`;
+let filesCreated = 0;
+let rejectedFiles = 0;
 
   try {
     if (!fs.existsSync(pathExists)) {
@@ -18,20 +20,39 @@ const pathExists = `./Controllers`;
   }
 
   args.map(function(res) {
-    fs.writeFile(`./Controllers/${res}Controller.js`, "", function(
-      err
-    ) {
-      if (err) throw err;
-    });
-
-    fs.copyFile(
-      `${__dirname}/controllerHolder.js`,
-      `./Controllers/${res}Controller.js`,
-
-      function(err) {
+    // check if the file name does not already exist
+    if(fs.existsSync(`./Controllers/${res}Controller.js`)) {
+      rejectedFiles++;
+    } else {
+      fs.writeFile(`./Controllers/${res}Controller.js`, "", function(
+        err
+      ) {
         if (err) throw err;
-      }
-    );
+      });
+  
+      fs.copyFile(
+        `${__dirname}/controllerHolder.js`,
+        `./Controllers/${res}Controller.js`,
+  
+        function(err) {
+          if (err) throw err;
+        }
+      );
+      filesCreated++;
+    }
   });
-  const fileCount = args.length > 1 ? "Files" : "File";
-  console.log(`${args.length} ${fileCount} created successfully.`);
+
+  // show the user the number of files created
+  if(rejectedFiles > 0) {
+    rejectedFiles === 1 ? console.log(`${rejectedFiles} FILE NOT CREATED : The file you are trying to create already exists`) 
+      : console.log(`${rejectedFiles} FILES NOT CREATED : The files you are trying to create already exist`);
+    
+  }
+
+  if(filesCreated > 0) {
+    if(filesCreated > 0) {
+      filesCreated === 1 ?  console.log(`${filesCreated} file created successfully.`) 
+        : console.log(`${args.length} ${filesCreated} files created successfully.`);
+    }
+  }
+  

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ let rejectedFiles = 0;
   if(filesCreated > 0) {
     if(filesCreated > 0) {
       filesCreated === 1 ?  console.log(`${filesCreated} file created successfully.`) 
-        : console.log(`${args.length} ${filesCreated} files created successfully.`);
+        : console.log(`${filesCreated} files created successfully.`);
     }
   }
   


### PR DESCRIPTION
I have added a step to check whether the files you are trying to create already exist. This improvement is necessary because if a user creates a controller and populates the controller with functions, it will not be prudent to override the content of that controller in an attempt to create a new controller. So instead of overriding the content of the controller with a new one, it's ok to keep the existing controller and tell the user that the controller name is already existing. This will prevent the user from loosing code that is already written in the controller.